### PR TITLE
Add Folia support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <revision>1.15.1</revision>
+        <revision>1.15.2</revision>
     </properties>
     <url>https://youhavetrouble.me</url>
 

--- a/src/main/java/me/youhavetrouble/enchantio/listeners/CloakingListener.java
+++ b/src/main/java/me/youhavetrouble/enchantio/listeners/CloakingListener.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 public class CloakingListener implements Listener {
 
-    private final HashMap<UUID, Long> ticksSinceLastMovement = new HashMap<>();
+    private final HashMap<UUID, Integer> ticksSinceLastMovement = new HashMap<>();
 
     private final CloakingEnchant cloakingEnchant = (CloakingEnchant) EnchantioConfig.ENCHANTS.get(CloakingEnchant.KEY);
     private final PotionEffect cloakingEffect = new PotionEffect(PotionEffectType.INVISIBILITY,  3, 0, false, false, false);
@@ -40,13 +40,13 @@ public class CloakingListener implements Listener {
         Bukkit.getGlobalRegionScheduler().runAtFixedRate(enchantio, (task) -> {
             for (Player player : Bukkit.getOnlinePlayers()) {
                 if (!player.isSneaking()) {
-                    ticksSinceLastMovement.put(player.getUniqueId(), 0L);
+                    ticksSinceLastMovement.put(player.getUniqueId(), 0);
                     continue;
                 }
                 int cloakingLevel = Enchantio.getSumOfEnchantLevels(player.getEquipment(), cloaking);
                 if (cloakingLevel == 0) continue;
                 ticksSinceLastMovement.computeIfPresent(player.getUniqueId(), (uuid, ticks) -> ticks + 1);
-                if (ticksSinceLastMovement.getOrDefault(player.getUniqueId(), 0L) < cloakingEnchant.getTicksToActivate()) continue;
+                if (ticksSinceLastMovement.getOrDefault(player.getUniqueId(), 0) < cloakingEnchant.getTicksToActivate()) continue;
                 player.getScheduler().execute(enchantio, () -> player.addPotionEffect(cloakingEffect), () -> {}, 1);
             }
         }, 1, 1);
@@ -54,7 +54,7 @@ public class CloakingListener implements Listener {
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     public void onPlayerJoin(PlayerJoinEvent event) {
-        ticksSinceLastMovement.put(event.getPlayer().getUniqueId(), 0L);
+        ticksSinceLastMovement.put(event.getPlayer().getUniqueId(), 0);
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
@@ -65,17 +65,17 @@ public class CloakingListener implements Listener {
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     public void onPlayerMove(PlayerMoveEvent event) {
         if (!event.hasChangedPosition()) return;
-        ticksSinceLastMovement.put(event.getPlayer().getUniqueId(), 0L);
+        ticksSinceLastMovement.put(event.getPlayer().getUniqueId(), 0);
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     public void onPlayerJump(PlayerJumpEvent event) {
-        ticksSinceLastMovement.put(event.getPlayer().getUniqueId(), 0L);
+        ticksSinceLastMovement.put(event.getPlayer().getUniqueId(), 0);
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     public void onPlayerInteract(PlayerInteractEvent event) {
-        ticksSinceLastMovement.put(event.getPlayer().getUniqueId(), 0L);
+        ticksSinceLastMovement.put(event.getPlayer().getUniqueId(), 0);
     }
 
 

--- a/src/main/java/me/youhavetrouble/enchantio/listeners/SmeltingListener.java
+++ b/src/main/java/me/youhavetrouble/enchantio/listeners/SmeltingListener.java
@@ -50,8 +50,7 @@ public class SmeltingListener implements Listener {
      */
     private ItemStack getSmeltedItem(@NotNull ItemStack itemStack) {
         ItemStack singleItem = itemStack.asOne();
-        ItemStack cached = smeltingCache.get(singleItem);
-        if (cached != null || smeltingCache.containsKey(singleItem)) return cached;
+        if (smeltingCache.containsKey(singleItem)) return smeltingCache.get(singleItem);
 
         for (@NotNull Iterator<Recipe> it = Bukkit.recipeIterator(); it.hasNext(); ) {
             Recipe recipe = it.next();

--- a/src/main/java/me/youhavetrouble/enchantio/listeners/SmeltingListener.java
+++ b/src/main/java/me/youhavetrouble/enchantio/listeners/SmeltingListener.java
@@ -50,7 +50,8 @@ public class SmeltingListener implements Listener {
      */
     private ItemStack getSmeltedItem(@NotNull ItemStack itemStack) {
         ItemStack singleItem = itemStack.asOne();
-        if (smeltingCache.containsKey(singleItem)) return smeltingCache.get(singleItem);
+        ItemStack cached = smeltingCache.get(singleItem);
+        if (cached != null || smeltingCache.containsKey(singleItem)) return cached;
 
         for (@NotNull Iterator<Recipe> it = Bukkit.recipeIterator(); it.hasNext(); ) {
             Recipe recipe = it.next();
@@ -60,6 +61,7 @@ public class SmeltingListener implements Listener {
             smeltingCache.put(singleItem, result);
             return result;
         }
+        smeltingCache.put(singleItem, null);
         return null;
     }
 

--- a/src/main/java/me/youhavetrouble/enchantio/listeners/TelepathyListener.java
+++ b/src/main/java/me/youhavetrouble/enchantio/listeners/TelepathyListener.java
@@ -6,7 +6,6 @@ import io.papermc.paper.registry.RegistryKey;
 import me.youhavetrouble.enchantio.Enchantio;
 import me.youhavetrouble.enchantio.EnchantioConfig;
 import me.youhavetrouble.enchantio.enchants.TelepathyEnchant;
-import org.bukkit.Bukkit;
 import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Item;
@@ -36,10 +35,14 @@ public class TelepathyListener implements Listener {
         }
 
         // If there's ever a performance problem here, it's the following
-        Bukkit.getScheduler().runTask(Enchantio.getPlugin(Enchantio.class), () -> event.getItems().forEach((item) -> {
-            if (item == null || item.isDead()) return;
-            item.teleport(event.getPlayer(), PlayerTeleportEvent.TeleportCause.PLUGIN);
-        }));
+        Enchantio enchantio = Enchantio.getPlugin(Enchantio.class);
+        event.getItems().forEach((item) -> {
+            if (item == null) return;
+            item.getScheduler().run(enchantio, (task) -> {
+                if (item.isDead()) return;
+                item.teleport(event.getPlayer(), PlayerTeleportEvent.TeleportCause.PLUGIN);
+            }, null);
+        });
     }
 
 }

--- a/src/main/java/me/youhavetrouble/enchantio/listeners/VampirismListener.java
+++ b/src/main/java/me/youhavetrouble/enchantio/listeners/VampirismListener.java
@@ -37,7 +37,7 @@ public class VampirismListener implements Listener {
                     }
 
                     player.setFireTicks(Math.max(fireTicks, player.getMaxFireTicks()));
-                }, () -> {}, 1);
+                }, () -> {}, 0);
             }
 
         }, 1, 20);

--- a/src/main/java/me/youhavetrouble/enchantio/listeners/VampirismListener.java
+++ b/src/main/java/me/youhavetrouble/enchantio/listeners/VampirismListener.java
@@ -19,22 +19,25 @@ public class VampirismListener implements Listener {
 
     public VampirismListener() {
         if (vampirism == null) return;
-        Bukkit.getGlobalRegionScheduler().runAtFixedRate(Enchantio.getPlugin(Enchantio.class), (task) -> {
+        Enchantio enchantio = Enchantio.getPlugin(Enchantio.class);
+        Bukkit.getGlobalRegionScheduler().runAtFixedRate(enchantio, (task) -> {
             for (Player player : Bukkit.getOnlinePlayers()) {
                 boolean hasVampirism = Enchantio.getSumOfEnchantLevels(player.getEquipment(), vampirism) != 0;
-                if (!hasVampirism) return;
-                Location abovePlayer = player.getLocation().add(0, player.getEyeHeight() + 0.5, 0);
-                Block block = player.getWorld().getBlockAt(abovePlayer);
-                byte light = block.getLightFromSky();
-                if (light < 15) return;
-                int fireTicks = player.getFireTicks();
+                if (!hasVampirism) continue;
+                player.getScheduler().execute(enchantio, () -> {
+                    Location abovePlayer = player.getLocation().add(0, player.getEyeHeight() + 0.5, 0);
+                    Block block = player.getWorld().getBlockAt(abovePlayer);
+                    byte light = block.getLightFromSky();
+                    if (light < 15) return;
+                    int fireTicks = player.getFireTicks();
 
-                // Prefent fire animation from disappearing on the client
-                if (player.getFireTicks() < 20) {
-                    fireTicks = 25;
-                }
+                    // Prefent fire animation from disappearing on the client
+                    if (player.getFireTicks() < 20) {
+                        fireTicks = 25;
+                    }
 
-                player.setFireTicks(Math.max(fireTicks, player.getMaxFireTicks()));
+                    player.setFireTicks(Math.max(fireTicks, player.getMaxFireTicks()));
+                }, () -> {}, 1);
             }
 
         }, 1, 20);

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -3,6 +3,7 @@ version: '${project.version}'
 main: me.youhavetrouble.enchantio.Enchantio
 bootstrapper: me.youhavetrouble.enchantio.EnchantioBootstrap
 api-version: '1.21.9'
+folia-supported: true
 authors: [YouHaveTrouble]
 description: Custom enchants for paper servers
 website: https://youhavetrouble.me


### PR DESCRIPTION
Folia thread-safety pass (all cross-region access found while adding Folia support has been resolved in this PR):
- Declares `folia-supported: true` in paper-plugin.yml
- Compiled against paper-api 1.21.10-R0.1-SNAPSHOT

Two listeners touched entity/world state from a scheduler that doesn't own the relevant region, which Folia doesn't allow:
- `TelepathyListener` scheduled the post-drop item teleport with `Bukkit.getScheduler().runTask(...)`, which isn't supported off Folia's global scheduler.
- `VampirismListener`'s fixed-rate global-region timer read player location/world blocks and mutated fire ticks directly, without first hopping onto the thread that owns the player's region.

This moves both onto Folia's per-entity scheduler (`Entity#getScheduler()`), the same pattern `CloakingListener` already uses elsewhere in the plugin: the global scheduler only does the cheap equipment check, then each entity's own scheduler handles anything touching location/block/world state. No behavior change on Paper; this only affects correctness under Folia.

While in there, picked up two small allocation cleanups: `SmeltingListener` now caches negative recipe lookups too (previously a non-smeltable drop re-scanned every registered furnace recipe on every hit), and `CloakingListener`'s per-tick sneak timer switched from a boxed `Long` map to `Integer`, since the activation threshold never exceeds a small int.